### PR TITLE
TFM-26 | Create DB in the same RDS instance

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -11,5 +11,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    postgresql = {
+      source  = "cyrilgdn/postgresql"
+      version = "~> 1.25.0"
+    }
   }
 }

--- a/databases.tf
+++ b/databases.tf
@@ -1,0 +1,9 @@
+# Create multiple databases using the database module
+module "app_database" {
+  source = "./modules/database"
+
+  database_name = "spring_boot_template_db"
+  username      = "app_user"
+  password      = "app_password_123"
+  rds_instance  = aws_db_instance.postgres
+}

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -1,0 +1,40 @@
+# Create database
+resource "postgresql_database" "database" {
+  name              = var.database_name
+  owner             = "postgres"
+  template          = "template0"
+  encoding          = "UTF8"
+  lc_collate        = "en_US.UTF-8"
+  lc_ctype          = "en_US.UTF-8"
+  tablespace_name   = "pg_default"
+  connection_limit  = -1
+  allow_connections = true
+
+  depends_on = [var.rds_instance]
+}
+
+# Create database user/role
+resource "postgresql_role" "user" {
+  name     = var.username
+  login    = true
+  password = var.password
+  roles    = []
+  search_path = []
+  statement_timeout = 0
+  inherit = true
+  replication = false
+  bypass_row_level_security = false
+
+  depends_on = [var.rds_instance]
+}
+
+# Grant privileges to user on the database
+resource "postgresql_grant" "user_privileges" {
+  database    = postgresql_database.database.name
+  role        = postgresql_role.user.name
+  schema      = "public"
+  object_type = "schema"
+  privileges  = ["CREATE", "USAGE"]
+
+  depends_on = [postgresql_database.database, postgresql_role.user]
+} 

--- a/modules/database/outputs.tf
+++ b/modules/database/outputs.tf
@@ -1,0 +1,19 @@
+output "database_name" {
+  description = "Name of the created database"
+  value       = postgresql_database.database.name
+}
+
+output "username" {
+  description = "Name of the created user/role"
+  value       = postgresql_role.user.name
+}
+
+output "database" {
+  description = "The created database resource"
+  value       = postgresql_database.database
+}
+
+output "user" {
+  description = "The created user/role resource"
+  value       = postgresql_role.user
+} 

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -1,0 +1,20 @@
+variable "database_name" {
+  description = "Name of the database to create"
+  type        = string
+}
+
+variable "username" {
+  description = "Username for the database user/role"
+  type        = string
+}
+
+variable "password" {
+  description = "Password for the database user/role"
+  type        = string
+  sensitive   = true
+}
+
+variable "rds_instance" {
+  description = "The RDS instance resource to depend on"
+  type        = any
+} 

--- a/modules/database/versions.tf
+++ b/modules/database/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    postgresql = {
+      source  = "cyrilgdn/postgresql"
+      version = "~> 1.25.0"
+    }
+  }
+} 

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,13 @@
 provider "aws" {
   region = "us-east-1"
 }
+
+provider "postgresql" {
+  host            = aws_db_instance.postgres.endpoint
+  port            = 5432
+  database        = "postgres"
+  username        = aws_db_instance.postgres.username
+  password        = aws_db_instance.postgres.password
+  sslmode         = "require"
+  connect_timeout = 15
+}


### PR DESCRIPTION
This pull request introduces PostgreSQL support to the Terraform configuration by adding a PostgreSQL provider, creating a reusable database module, and configuring a database and user for an application. Below are the most important changes grouped by theme:

### PostgreSQL Provider Integration:
* Added `postgresql` provider configuration in `providers.tf` with connection details to the PostgreSQL instance. This enables Terraform to manage PostgreSQL resources.

### Database Module Setup:
* Created a reusable database module (`modules/database`) with resources for creating a PostgreSQL database, user/role, and granting privileges. Includes `postgresql_database`, `postgresql_role`, and `postgresql_grant` resources.
* Added input variables (`database_name`, `username`, `password`, `rds_instance`) to the module in `variables.tf` for flexibility and reusability.
* Defined outputs (`database_name`, `username`, `database`, `user`) in `outputs.tf` to expose key module details for consumption by other modules.

### Application Database Configuration:
* Configured a new `app_database` module in `databases.tf` to create a database (`spring_boot_template_db`) and user (`app_user`) for the application, using the reusable database module.

### Terraform Backend Updates:
* Added `postgresql` provider to the `terraform` block in `backend.tf` to include the PostgreSQL module as part of the configuration.